### PR TITLE
Expand todo API tools

### DIFF
--- a/src/tools.py
+++ b/src/tools.py
@@ -1,17 +1,64 @@
+"""LangChain tools for interacting with the todo app."""
+
+from typing import Optional
 from langchain_core.tools import tool
 
-from src.core import add_task, list_tasks
+from src.core import (
+    add_task,
+    finish_task,
+    list_tasks,
+    remove_task,
+    update_task,
+)
 from src.utils import parse_date
 
 
 @tool
 def add_task_tool(name: str, description: str = "", due: str = "") -> dict:
-    task = {"name": name, "description": description, "due_date": parse_date(due)}
-    return add_task(task)["info"]
+    """Add a new task."""
+
+    task = {"name": name, "description": description, "due": parse_date(due)}
+    return add_task(task)
 
 
 @tool
-def list_tasks_tool(status: str):
-    tasks = list_tasks(status)
+def list_tasks_tool(status: str = "all") -> list:
+    """List tasks filtered by status."""
 
+    tasks = list_tasks(status)
     return tasks
+
+
+@tool
+def update_task_tool(task_id: str, name: Optional[str] = None,
+                     description: Optional[str] = None,
+                     due: Optional[str] = None) -> dict:
+    """Update an existing task."""
+
+    fields = {
+        "name": name,
+        "description": description,
+        "due": parse_date(due) if due else None,
+    }
+    return update_task(task_id, fields)
+
+
+@tool
+def finish_task_tool(task_id: str) -> dict:
+    """Mark a task as finished."""
+
+    return finish_task(task_id)
+
+
+@tool
+def remove_task_tool(task_id: str) -> dict:
+    """Remove a task by id."""
+
+    return remove_task(task_id)
+
+
+@tool
+def delete_task_tool(task_id: str) -> dict:
+    """Alias for :func:`remove_task_tool`."""
+
+    return remove_task(task_id)


### PR DESCRIPTION
## Summary
- complete the tool suite for the todo list API
- fix add/list helpers
- add update, finish and remove helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687c74b890dc832db641daf56995ba65